### PR TITLE
Use fork instead of spawn for tns command

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "devDependencies": {
     "grunt": "^0.4.5",
-    "grunt-shell": "^1.1.2"
+    "grunt-shell": "^1.1.2",
+    "shelljs": "0.5.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karma-nativescript-launcher",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
When using spawn we communicate to the tns process through stdin. This is causing exception in buildMetadata step when gradle wrapper is used.
For some reason it throws error in java code.
Replace the spawn with fork. Fork requires JavaScript module, so use the nativescript-cli.js from bin folder in case the provided options do not send path to tns.
The child process will send "ready" to the parent, when it is ready to read data. In this moment the parent will send the configuration and the unit testing will start.
