### PR TITLE
Change the way karma communicate with CLI

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,13 +31,6 @@ function NativeScriptLauncher(baseBrowserDecorator, logger, config, args, emitte
 
 	var launcherConfig = config._NS || {};
 
-	emitter.on('file_list_modified', function() {
-		self.log.info('Deploying NativeScript unit tests...');
-		if (self.parsedUrl) {
-			self.liveSyncAndRun(self.parsedUrl);
-		}
-	})
-
 	emitter.on('browser_register', function(browser) {
 		if (!browser.id || browser.id.indexOf('NativeScript') !== 0) {
 			return;
@@ -52,6 +45,7 @@ function NativeScriptLauncher(baseBrowserDecorator, logger, config, args, emitte
 		process.stdout.write(data);
 	}
 
+	// Consider removing this in case we drop support for `tns dev-test` command
 	self.liveSyncAndRun = function() {
 		var tnsArgs = ['dev-test', self.platform, '--port', self.parsedUrl.port];
 		if (args.arguments) {
@@ -91,7 +85,7 @@ function NativeScriptLauncher(baseBrowserDecorator, logger, config, args, emitte
 
 	self.start = function(url) {
 		self.parsedUrl = URL.parse(url);
-		self.liveSyncAndRun();
+		process.send({ url: self.parsedUrl, launcherConfig: JSON.stringify(launcherConfig.options) });
 	}
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karma-nativescript-launcher",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Currently karma-nativescript-launcher was spawning new CLI process. From now on CLI will start karma in a forked process.
So we have to send information to CLI for karma's configuration after it's been started.
Remove listening for `file_list_modified` event as we already have file system watchers in CLI.
