### PR TITLE
Do not schedule execution in case `--watch` is not set

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,14 @@ function NativeScriptLauncher(baseBrowserDecorator, logger, config, args, emitte
 
 		self.markCaptured();
 
-		executor.schedule();
+		// In case --watch is passed to CLI, each change in file should restart the tests.
+		// When a new browser is registered, in case `singleRun` is false (that's when --watch is not passed)
+		// tests should be scheduled.
+		// When `singleRun` is true, karma automatically runs the tests when browser is registered,
+		// so do not schedule them in this case.
+		if(launcherConfig.options.watch) {
+			executor.schedule();
+		}
 	});
 
 	function logDebugOutput(data) {


### PR DESCRIPTION
In case `--watch` is not set, CLI will set `singleRun` option of karma config to true. This way on browser register event, karma will automatically run the tests.
In case `--watch` is set, any change in code should start new tests, so when browser is registered, schedule new execution and karma will add the test execution to the queue and execute them when available.

Fixes https://github.com/NativeScript/nativescript-cli/issues/1625
